### PR TITLE
Focus name input on item edit

### DIFF
--- a/js/items-manager.js
+++ b/js/items-manager.js
@@ -524,11 +524,7 @@ class ItemsManager {
         console.log('🥕 Attaching form listeners...');
         this.attachFullPageItemFormListeners(item);
         
-        // Focus on name input
-        setTimeout(() => {
-            const nameInput = document.querySelector('#item-name');
-            if (nameInput) nameInput.focus();
-        }, 100);
+        // Note: Removed automatic focus to prevent mobile keyboard from opening
     }
 
     generateFullPageItemFormHTML(item = null) {

--- a/js/meal-manager.js
+++ b/js/meal-manager.js
@@ -576,10 +576,7 @@ class MealManager {
         document.body.appendChild(modal);
         this.attachMealFormListeners();
 
-        // Focus on name input
-        setTimeout(() => {
-            document.getElementById('meal-name')?.focus();
-        }, 100);
+        // Note: Removed automatic focus to prevent mobile keyboard from opening
     }
 
     renderRecipeSelection(selectedRecipes = []) {

--- a/js/recipe-manager.js
+++ b/js/recipe-manager.js
@@ -2271,11 +2271,7 @@ class RecipeManager {
         // Attach event listeners
         this.attachRecipeFormListeners(modal, recipe);
         
-        // Focus on title input
-        setTimeout(() => {
-            const titleInput = modal.querySelector('#recipe-title');
-            if (titleInput) titleInput.focus();
-        }, 100);
+        // Note: Removed automatic focus to prevent mobile keyboard from opening
     }
 
     /**

--- a/src/components/items-manager.js
+++ b/src/components/items-manager.js
@@ -305,8 +305,7 @@ export class ItemsManager {
             this.saveIngredient(ingredient?.id, modal)
         })
         
-        // Focus on name field
-        document.getElementById('ingredient-name').focus()
+        // Note: Removed automatic focus to prevent mobile keyboard from opening
     }
 
     async saveIngredient(ingredientId, modal) {


### PR DESCRIPTION
Remove automatic focus from edit forms to prevent the mobile keyboard from opening.

---
<a href="https://cursor.com/background-agent?bcId=bc-d457a886-7c15-4eb9-b728-d11bbfd1c777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d457a886-7c15-4eb9-b728-d11bbfd1c777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

