### PR TITLE
Fix item info box recipe count

### DIFF
--- a/js/recipe-manager.js
+++ b/js/recipe-manager.js
@@ -602,7 +602,7 @@ class RecipeManager {
                             ${(recipe.labels || []).length > (recipe.favorite ? 1 : 2) ? `<span class="text-xs text-gray-500">+${(recipe.labels || []).length - (recipe.favorite ? 1 : 2)} more</span>` : ''}
                         </div>
                         <div class="text-xs text-gray-400">
-                            ${recipe.recipe_type === 'combo' ? 
+                            ${(recipe.recipe_type === 'combo' && ((recipe.recipes && recipe.recipes.length > 0) || (recipe.combo_recipes && recipe.combo_recipes.length > 0))) ? 
                                 `${this.getCombinedItemsForCombo(recipe).length} items (from ${recipe.recipes ? recipe.recipes.length : (recipe.combo_recipes ? recipe.combo_recipes.length : 0)} recipes)` : 
                                 `${(recipe.items || []).length} items`
                             }


### PR DESCRIPTION
Update recipe item count display logic to correctly show "from X recipes" only for actual combo recipes.

Previously, regular recipes or combo recipes without sub-recipes would incorrectly display "from X recipes" because the condition `recipe.recipe_type === 'combo'` was not sufficient. The updated logic now also checks for the presence and length of `recipes` or `combo_recipes` arrays.

---
<a href="https://cursor.com/background-agent?bcId=bc-5628eeb0-d927-4476-a91b-95ab4aaa43f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5628eeb0-d927-4476-a91b-95ab4aaa43f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

