### PR TITLE
Fix recipe page sorting toggle

### DIFF
--- a/js/recipe-manager.js
+++ b/js/recipe-manager.js
@@ -1124,7 +1124,9 @@ class RecipeManager {
                 this.sortAscending = !this.sortAscending;
                 // Need to re-render for sort direction button to update its icon
                 this.render();
+                this.attachEventListeners(); // Reattach event listeners after render
                 this.updateFavoritesButton(); // Ensure favorites button maintains correct state after render
+                this.updateRecipeDisplay(); // Apply the new sort direction to the recipes
             });
         }
 


### PR DESCRIPTION
Call `updateRecipeDisplay()` when toggling sort direction to ensure recipes are re-sorted and displayed correctly.

Previously, toggling the sort direction only updated the button icon and re-rendered the UI, but did not trigger the logic to re-sort the actual recipe list.

---
<a href="https://cursor.com/background-agent?bcId=bc-0cf97777-b665-432c-9e68-4cbf18c0abe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0cf97777-b665-432c-9e68-4cbf18c0abe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

