### PR TITLE
Fix info box zero label bug

### DIFF
--- a/js/recipe-manager.js
+++ b/js/recipe-manager.js
@@ -754,6 +754,10 @@ class RecipeManager {
             if (recipe.tags && Array.isArray(recipe.tags)) {
                 recipe.tags.forEach(tag => labels.add(tag));
             }
+            // Include "Favorite" as a label when recipe is favorited
+            if (recipe.favorite === true) {
+                labels.add('Favorite');
+            }
         });
         return Array.from(labels);
     }

--- a/src/test/unit/recipe-manager-infobox.test.js
+++ b/src/test/unit/recipe-manager-infobox.test.js
@@ -148,6 +148,10 @@ class MockRecipeManagerWithInfoBox {
             if (recipe.labels) {
                 recipe.labels.forEach(label => allLabels.add(label));
             }
+            // Include "Favorite" as a label when recipe is favorited
+            if (recipe.favorite === true) {
+                allLabels.add('Favorite');
+            }
         });
         
         return Array.from(allLabels);
@@ -280,7 +284,7 @@ describe('Recipe Manager Info Box Updates', () => {
             const favoriteCount = container.querySelector('#favorite-count');
             
             expect(recipeCount.textContent).toBe('3'); // All 3 recipes
-            expect(labelCount.textContent).toBe('7'); // All unique labels (protein-rich, low-carb, Dinner, vegetarian, Lunch, dessert, sweet)
+            expect(labelCount.textContent).toBe('8'); // All unique labels (protein-rich, low-carb, Dinner, vegetarian, Lunch, dessert, sweet) + Favorite
             expect(favoriteCount.textContent).toBe('2'); // 2 favorites
         });
 
@@ -307,7 +311,7 @@ describe('Recipe Manager Info Box Updates', () => {
             const favoriteCount = container.querySelector('#favorite-count');
             
             expect(recipeCount.textContent).toBe('1'); // Only chicken recipe
-            expect(labelCount.textContent).toBe('3'); // Labels from chicken recipe
+            expect(labelCount.textContent).toBe('4'); // Labels from chicken recipe + Favorite
             expect(favoriteCount.textContent).toBe('1'); // Chicken is favorite
         });
 


### PR DESCRIPTION
Fixes info box label count to include "Favorite" status, aligning visual representation with summary statistics.

Previously, the `getFilteredLabels()` method only considered explicit labels in the `recipe.labels` array. The "Favorite" status, while visually displayed as a label on recipe cards, was not part of this array, causing the label count in the filter summary to be inaccurate when favorite recipes were present. This change ensures that the "Favorite" status is counted as a label, resolving the discrepancy.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c0fe621-1f66-4179-b640-b74a83109179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c0fe621-1f66-4179-b640-b74a83109179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

