### PR TITLE
Sync grocery list with menu schedule

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2217,17 +2217,21 @@ class MealPlannerApp {
             });
         }
         
-        // Update grocery list with the same date range
-        if (window.groceryListManager && window.groceryListManager.updateDateRange) {
-            window.groceryListManager.updateDateRange(startDate, endDate);
-        }
-        
         if (scheduledMeals.length === 0) {
             mealsContainer.innerHTML = `
                 <div class="text-gray-500 dark:text-gray-400 text-center py-4">
                     No meals scheduled for this timeframe. Use the Plan tab to schedule meals.
                 </div>
             `;
+            
+            // Update grocery list even when no meals to ensure it reflects the empty state
+            // Use a small delay to ensure DOM is fully updated before updating grocery list
+            setTimeout(() => {
+                if (window.groceryListManager && window.groceryListManager.updateDateRange) {
+                    window.groceryListManager.updateDateRange(startDate, endDate);
+                    console.log('🛒 Grocery list updated for empty menu state');
+                }
+            }, 50);
             return;
         }
         
@@ -2290,6 +2294,16 @@ class MealPlannerApp {
         mealsContainer.innerHTML = mealsHTML;
         console.log(`📅 Updated Menu tab with ${scheduledMeals.length} meals for ${weeks} week(s)`);
         console.log(`📅 Menu date range: ${startDate.toLocaleDateString()} to ${endDate.toLocaleDateString()}`);
+        
+        // Update grocery list AFTER menu page is updated to ensure proper synchronization
+        // This ensures the grocery list reflects the actual scheduled meals shown on the menu page
+        // Use a small delay to ensure DOM is fully updated before updating grocery list
+        setTimeout(() => {
+            if (window.groceryListManager && window.groceryListManager.updateDateRange) {
+                window.groceryListManager.updateDateRange(startDate, endDate);
+                console.log('🛒 Grocery list updated after menu page display');
+            }
+        }, 50);
         
         // Debug: Detailed Menu tab meal analysis
         console.log(`🔍 DETAILED MENU TAB ANALYSIS:`);


### PR DESCRIPTION
Reorder grocery list update to happen after menu page display to ensure synchronization.

Previously, the grocery list was updated within `updateMenuMealsDisplay()` before the menu page's HTML was rendered. This caused the grocery list to reflect delta changes before they were visually present on the menu page. This PR reorders the update to occur after the menu HTML is generated and displayed, ensuring the grocery list always synchronizes with the visible menu content.

---
<a href="https://cursor.com/background-agent?bcId=bc-c21b7817-7534-4b7a-a703-ba29d9f5ea0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c21b7817-7534-4b7a-a703-ba29d9f5ea0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

