### PR TITLE
Improve recipe label management and navigation

### DIFF
--- a/js/recipe-manager.js
+++ b/js/recipe-manager.js
@@ -1612,6 +1612,14 @@ class RecipeManager {
             // Re-attach event listeners for the restored content
             this.attachEventListeners();
             
+            // Check if we're returning to a recipe form and refresh labels dropdown
+            const fullpageLabelsDropdown = document.querySelector('#fullpage-recipe-labels-dropdown');
+            if (fullpageLabelsDropdown) {
+                console.log('🔄 Refreshing labels dropdown after returning from label management...');
+                // Refresh the labels dropdown to show any new labels
+                this.updateFullPageLabelDropdown();
+            }
+            
             // Clear the stored content
             this.originalRecipeContent = null;
         }
@@ -4172,7 +4180,16 @@ class RecipeManager {
                         </div>
 
                         <!-- Form Actions -->
-                        <div class="flex justify-end pt-6 border-t border-gray-200 dark:border-gray-700">
+                        <div class="flex justify-between items-center pt-6 border-t border-gray-200 dark:border-gray-700">
+                            <!-- Left side: Labels management link -->
+                            <button type="button" id="manage-labels-from-form" class="flex items-center gap-2 px-4 py-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-md transition-colors">
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"></path>
+                                </svg>
+                                <span>Manage Labels</span>
+                            </button>
+                            
+                            <!-- Right side: Save button -->
                             <button type="submit" class="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-lg">
                                 ${isEdit ? (isCombo ? 'Update Combo' : 'Update Recipe') : (isCombo ? 'Save Combo' : 'Save Recipe')}
                             </button>
@@ -4537,6 +4554,41 @@ class RecipeManager {
                 itemsContainer: '#items-container',
                 isCombo: isCombo
             });
+        }
+
+        // Attach labels management button listener
+        const manageLabelsBtn = document.querySelector('#manage-labels-from-form');
+        if (manageLabelsBtn) {
+            manageLabelsBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                console.log('🏷️ Opening labels management from recipe form...');
+                this.showLabelManagement();
+            });
+        }
+
+        // Attach full-page label listeners
+        this.attachFullPageLabelListeners();
+    }
+
+    returnFromFullPageForm() {
+        console.log('📄 Returning from full-page recipe form...');
+        
+        // Restore the previous view
+        if (this.previousView) {
+            this.container.innerHTML = this.previousView.container;
+            
+            // Restore scroll position
+            window.scrollTo(0, this.previousView.scrollPosition);
+            
+            // Re-attach event listeners for the restored content
+            this.attachEventListeners();
+            
+            // Clear the stored view
+            this.previousView = null;
+        } else {
+            // Fallback: just render the normal recipe list
+            this.render();
+            this.attachEventListeners();
         }
     }
 


### PR DESCRIPTION
Add a "Manage Labels" link to the recipe form, refresh the labels dropdown after management, and ensure correct navigation back to the recipe form.

This allows users to easily create new labels while creating or editing recipes, with new labels immediately available in the dropdown. The navigation ensures a smooth return to the recipe form, preserving the user's context.

---
<a href="https://cursor.com/background-agent?bcId=bc-13b7fba6-07d2-490b-8882-8b572022ee71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-13b7fba6-07d2-490b-8882-8b572022ee71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

