### PR TITLE
Fix combo count increment bug in default mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,12 @@
                     <!-- Pending Recipes Queue -->
                     <div id="pending-recipes-section" class="mb-8 bg-white dark:bg-gray-800 rounded-lg shadow p-6">
                         <div class="flex items-center justify-between mb-4">
-                            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Planning Queue <span id="planning-queue-count" class="text-blue-600 dark:text-blue-400">(0)</span></h3>
+                            <div class="flex items-center gap-4">
+                                <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Planning Queue <span id="planning-queue-count" class="text-blue-600 dark:text-blue-400">(0)</span></h3>
+                                <div id="combo-count" class="text-sm text-purple-600 dark:text-purple-400 bg-purple-100 dark:bg-purple-900/30 px-2 py-1 rounded-full">
+                                    <strong>0</strong> combos
+                                </div>
+                            </div>
                             <button id="clear-pending-recipes" class="text-sm text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300">
                                 Clear All
                             </button>


### PR DESCRIPTION
Add missing `combo-count` HTML element to display the combo count in the planning queue.

---
<a href="https://cursor.com/background-agent?bcId=bc-06d560fc-a93d-4d85-94ca-6f0354d5b72d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06d560fc-a93d-4d85-94ca-6f0354d5b72d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

