### PR TITLE
Fix recipe label search and type ahead

### DIFF
--- a/js/recipe-manager.js
+++ b/js/recipe-manager.js
@@ -1656,10 +1656,18 @@ class RecipeManager {
             
             // Check if we're returning to a recipe form and refresh labels dropdown
             const fullpageLabelsDropdown = document.querySelector('#fullpage-recipe-labels-dropdown');
+            const modalLabelsDropdown = document.querySelector('#recipe-form-labels-dropdown');
+            
             if (fullpageLabelsDropdown) {
-                console.log('🔄 Refreshing labels dropdown after returning from label management...');
+                console.log('🔄 Refreshing full-page labels dropdown after returning from label management...');
                 // Refresh the labels dropdown to show any new labels
                 this.updateFullPageLabelDropdown();
+            }
+            
+            if (modalLabelsDropdown) {
+                console.log('🔄 Refreshing modal labels dropdown after returning from label management...');
+                // Refresh the modal labels dropdown to show any new labels
+                this.updateFormLabelDropdown();
             }
             
             // Clear the stored content
@@ -2722,8 +2730,13 @@ class RecipeManager {
             (!this.formLabelSearchTerm || (label.name || label).toLowerCase().includes(this.formLabelSearchTerm.toLowerCase()))
         );
 
-        if (availableLabels.length === 0 || !this.formLabelSearchTerm) {
-            dropdown.classList.add('hidden');
+        if (availableLabels.length === 0) {
+            dropdown.innerHTML = `
+                <div class="px-3 py-2 text-gray-500 dark:text-gray-400 text-sm">
+                    ${this.formLabelSearchTerm ? `No labels found matching "${this.formLabelSearchTerm}"` : 'No more labels available'}
+                </div>
+            `;
+            dropdown.classList.remove('hidden');
             return;
         }
 
@@ -5037,8 +5050,13 @@ class RecipeManager {
             (!this.formLabelSearchTerm || (label.name || label).toLowerCase().includes(this.formLabelSearchTerm.toLowerCase()))
         );
 
-        if (availableLabels.length === 0 || !this.formLabelSearchTerm) {
-            dropdown.classList.add('hidden');
+        if (availableLabels.length === 0) {
+            dropdown.innerHTML = `
+                <div class="px-3 py-2 text-gray-500 dark:text-gray-400 text-sm">
+                    ${this.formLabelSearchTerm ? `No labels found matching "${this.formLabelSearchTerm}"` : 'No more labels available'}
+                </div>
+            `;
+            dropdown.classList.remove('hidden');
             return;
         }
 


### PR DESCRIPTION
Fix labels search on create and edit recipe pages to enable type-ahead and show newly created labels.

Previously, the label dropdowns on recipe forms were hidden when no search term was entered, preventing type-ahead functionality and the display of all available labels, including newly created ones. This PR modifies the dropdown logic to always show available labels (or a "no labels" message) and refreshes modal form dropdowns after label management.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ca715d0-d70f-4e43-95c0-35e2b3670fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1ca715d0-d70f-4e43-95c0-35e2b3670fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

