### PR TITLE
Fix recipe list sort button after one use

### DIFF
--- a/js/recipe-manager.js
+++ b/js/recipe-manager.js
@@ -1126,7 +1126,6 @@ class RecipeManager {
                 this.render();
                 this.attachEventListeners(); // Reattach event listeners after render
                 this.updateFavoritesButton(); // Ensure favorites button maintains correct state after render
-                this.updateRecipeDisplay(); // Apply the new sort direction to the recipes
             });
         }
 


### PR DESCRIPTION
Remove redundant `updateRecipeDisplay()` call to fix ASC/DESC sort button functionality.

The sort direction button's click handler was calling both `this.render()` and `this.updateRecipeDisplay()`. Since `this.render()` already internally calls `renderRecipeCards()` (which applies the sorting), the subsequent `this.updateRecipeDisplay()` call was redundant and caused the sorting logic to be applied twice, breaking the button after the first use.

---
<a href="https://cursor.com/background-agent?bcId=bc-a45cd37e-df5f-461e-99fb-0789db16f2f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a45cd37e-df5f-461e-99fb-0789db16f2f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

